### PR TITLE
Ensure the consistent use of the Google US English voice when USE_GOOGLE_VOICE is set to true.

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -19,7 +19,7 @@ window.onload = function() { //SMMRY API abstraction
         }
         $.each(arr, function () {
             var u = new SpeechSynthesisUtterance(this.trim());
-            u.voice = utt.voice
+            u.voice = utt.voice;
             window.speechSynthesis.speak(u);
         });
     };

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
 var TEXT_TOO_SHORT_ERROR = "Input text too short. Are you SURE you need to tl;dr that?";
-var USE_GOOGLE_VOICE = true;
+var USE_GOOGLE_VOICE = false;
 window.onload = function() { //SMMRY API abstraction
     //https://github.com/Dogfalo/materialize/issues/1503
     window.speechSynthesis.cancel();

--- a/popup.js
+++ b/popup.js
@@ -24,6 +24,8 @@ window.onload = function() { //SMMRY API abstraction
             //This defaults to chrome
             if (USE_GOOGLE_VOICE) {
                 var utterance = new SpeechSynthesisUtterance(res.sm_api_content);
+                var voices = window.speechSynthesis.getVoices();
+                utterance.voice = voices.filter(function(voice) { return voice.name == "Google US English"; })[0];
                 window.speechSynthesis.speak(utterance);
             } else {
                 //this calls uphony QQ

--- a/popup.js
+++ b/popup.js
@@ -7,62 +7,21 @@ window.onload = function() { //SMMRY API abstraction
 
     document.title = "Summary to Speech";
 
-    var speechUtteranceChunker = function (utt, settings, callback) {
-        settings = settings || {};
-        var newUtt;
-        var txt = (settings && settings.offset !== undefined ? utt.text.substring(settings.offset) : utt.text);
-        if (utt.voice && utt.voice.voiceURI === 'native') { // Not part of the spec
-            newUtt = utt;
-            newUtt.text = txt;
-            newUtt.addEventListener('end', function () {
-                if (speechUtteranceChunker.cancel) {
-                    speechUtteranceChunker.cancel = false;
-                }
-                if (callback !== undefined) {
-                    callback();
-                }
-            });
-        }
-        {
-            var chunkLength = (settings && settings.chunkLength) || 160;
-            var pattRegex = new RegExp('^[\\s\\S]{' + Math.floor(chunkLength / 2) + ',' + chunkLength + '}[.!?,]{1}|^[\\s\\S]{1,' + chunkLength + '}$|^[\\s\\S]{1,' + chunkLength + '} ');
-            var chunkArr = txt.match(pattRegex);
+    var speechUtteranceChunker = function (utt, chunkSize, callback) {
+      var chunkLength = chunkSize;
+      var pattRegex = new RegExp('^[\\s\\S]{' + Math.floor(chunkLength / 2) + ',' + chunkLength + '}[.!?,]{1}|^[\\s\\S]{1,' + chunkLength + '}$|^[\\s\\S]{1,' + chunkLength + '} ');
 
-            if (chunkArr[0] === undefined || chunkArr[0].length <= 2) {
-                //call once all text has been spoken...
-                if (callback !== undefined) {
-                    callback();
-                }
-                return;
-            }
-            var chunk = chunkArr[0];
-            newUtt = new SpeechSynthesisUtterance(chunk);
-            var x;
-            for (x in utt) {
-                if (utt.hasOwnProperty(x) && x !== 'text') {
-                    newUtt[x] = utt[x];
-                }
-            }
-            newUtt.addEventListener('end', function () {
-                if (speechUtteranceChunker.cancel) {
-                    speechUtteranceChunker.cancel = false;
-                    return;
-                }
-                settings.offset = settings.offset || 0;
-                settings.offset += chunk.length - 1;
-                speechUtteranceChunker(utt, settings, callback);
-            });
+      var arr = [];
+      var txt = utt.text
+      while (txt.length > 0) {
+            arr.push(txt.match(pattRegex)[0]);
+            txt = txt.substring(arr[arr.length - 1].length);
         }
-
-        if (settings.modifier) {
-            settings.modifier(newUtt);
-        }
-        console.log(newUtt); //IMPORTANT!! Do not remove: Logging the object out fixes some onend firing issues.
-        //placing the speak invocation inside a callback fixes ordering and onend issues.
-        setTimeout(function () {
-            newUtt.voice = utt.voice;
-            speechSynthesis.speak(newUtt);
-        }, 0);
+        $.each(arr, function () {
+            var u = new SpeechSynthesisUtterance(this.trim());
+            u.voice = utt.voice
+            window.speechSynthesis.speak(u);
+        });
     };
 
     function handleTextSMMRYAsync(res) {
@@ -84,7 +43,7 @@ window.onload = function() { //SMMRY API abstraction
                 var utterance = new SpeechSynthesisUtterance(res.sm_api_content);
                 var voices = window.speechSynthesis.getVoices();
                 utterance.voice = voices.filter(function(voice) { return voice.name == "Google US English"; })[0];
-                speechUtteranceChunker(utterance, {chunkLength: 160}, function () {
+                speechUtteranceChunker(utterance, 160, function () {
                   //some code to execute when done
                   console.log('Finished speaking.');
                 });

--- a/popup.js
+++ b/popup.js
@@ -84,7 +84,7 @@ window.onload = function() { //SMMRY API abstraction
                 var utterance = new SpeechSynthesisUtterance(res.sm_api_content);
                 var voices = window.speechSynthesis.getVoices();
                 utterance.voice = voices.filter(function(voice) { return voice.name == "Google US English"; })[0];
-                speechUtteranceChunker(utterance, {chunkLength: 300}, function () {
+                speechUtteranceChunker(utterance, {chunkLength: 160}, function () {
                   //some code to execute when done
                   console.log('Finished speaking.');
                 });


### PR DESCRIPTION
When USE_GOOGLE_VOICE is set to true, the speechSynthesis API doesn't necessarily use the correct voice (resulting in non-native voice, such as German or Italian attempting to read English.)

If you would like to see what I'm talking about, you may comment out `utterance.voice = voices.filter(function(voice) { return voice.name == "Google US English"; })[0];` and `u.voice = utt.voice;` on lines 45 and 22 of `popup.js` respectively.

However, making this change also resulted in cut outs, where speech would suddenly end mid-sentence (which the problem and a solution is outlined in detail [here](http://stackoverflow.com/a/23808155)).

These commits implement this change, and the fix. Now, these changes don't come without bugs (notably the player view doesn't appear when USE_GOOGLE_VOICE is set to true).
